### PR TITLE
Fix 3D-DCT and make minor corrections in test cases

### DIFF
--- a/code/+tansacnet/+testcase/+lsun/lsunAnalysis1dNetworkTestCase.m
+++ b/code/+tansacnet/+testcase/+lsun/lsunAnalysis1dNetworkTestCase.m
@@ -136,7 +136,7 @@ classdef lsunAnalysis1dNetworkTestCase < matlab.unittest.TestCase
                 'DType',datatype, ...
                 'Device',device);
             dlnet = net.dlnetwork();
-            analyzeNetwork(dlnet)
+            % analyzeNetwork(dlnet)
             dlnet_ = initialize(dlnet);
             
             X = rand([1, 100, 1, 1], datatype);
@@ -209,7 +209,7 @@ classdef lsunAnalysis1dNetworkTestCase < matlab.unittest.TestCase
                 'DType',datatype, ...
                 'Device',device);
             dlnet = net.dlnetwork();
-            analyzeNetwork(dlnet)
+            % analyzeNetwork(dlnet)
             dlnet_ = initialize(dlnet);
 
             X = dlarray(X, 'SSCB');
@@ -299,7 +299,7 @@ classdef lsunAnalysis1dNetworkTestCase < matlab.unittest.TestCase
                 'DType',datatype, ...
                 'Device',device);
             dlnet = net.dlnetwork();
-            analyzeNetwork(dlnet)
+            % analyzeNetwork(dlnet)
             dlnet_ = initialize(dlnet);
 
             X = dlarray(X, 'SSCB');

--- a/code/+tansacnet/+testcase/+lsun/lsunAnalysis2dNetworkTestCase.m
+++ b/code/+tansacnet/+testcase/+lsun/lsunAnalysis2dNetworkTestCase.m
@@ -250,7 +250,7 @@ classdef lsunAnalysis2dNetworkTestCase < matlab.unittest.TestCase
                 'Device',device);
             dlnet = net.dlnetwork();
             dlnet_ = initialize(dlnet);
-            analyzeNetwork(dlnet)
+            % analyzeNetwork(dlnet)
             
             X = dlarray(X, 'SSCB');
             [Zac,Zdc] = forward(dlnet_, X);

--- a/code/+tansacnet/+testcase/+lsun/lsunBlockDct3dLayerTestCase.m
+++ b/code/+tansacnet/+testcase/+lsun/lsunBlockDct3dLayerTestCase.m
@@ -22,7 +22,7 @@ classdef lsunBlockDct3dLayerTestCase < matlab.unittest.TestCase
     % http://msiplab.eng.niigata-u.ac.jp/
     %
     properties (TestParameter)
-        stride = { [1 1 1], [2 2 2], [1 2 4] };
+        stride = { [1 1 1], [2 2 2], [1 2 4], [4 4 4] };
         datatype = { 'single', 'double' };
         height = struct('small', 8,'medium', 16, 'large', 32);
         width = struct('small', 8,'medium', 16, 'large', 32);
@@ -223,143 +223,39 @@ classdef lsunBlockDct3dLayerTestCase < matlab.unittest.TestCase
 
         function value = getMatrixE0_(decFactor)
             import tansacnet.utility.Direction
-            decY_ = decFactor(Direction.VERTICAL);
-            decX_ = decFactor(Direction.HORIZONTAL);
-            decZ_ = decFactor(Direction.DEPTH);
-            nElmBi = decY_*decX_*decZ_;
-            coefs = zeros(nElmBi);
-            iElm = 1;
-            % E0.'= [ Beee Beoo Booe Boeo Beeo Beoe Booo Boee ] % Byxz
-            % Beee
-            for iRow = 1:2:decY_ % y-e
-                for iCol = 1:2:decX_ % x-e
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 1:2:decZ_ % z-e
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            % Beoo
-            for iRow = 1:2:decY_ % y-e
-                for iCol = 2:2:decX_ % x-o
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 2:2:decZ_ % z-o
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Booe
-            for iRow = 2:2:decY_ % y-o
-                for iCol = 2:2:decX_ % x-o
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 1:2:decZ_ % z-e
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Boeo
-            for iRow = 2:2:decY_ % y-o
-                for iCol = 1:2:decX_ % x-e
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 2:2:decZ_ % z-o
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Beeo
-            for iRow = 1:2:decY_ % y-e
-                for iCol = 1:2:decX_ % x-e
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 2:2:decZ_ % z-o
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Beoe
-            for iRow = 1:2:decY_ % y-e
-                for iCol = 2:2:decX_ % x-o
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 1:2:decZ_ % z-e
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Booo
-            for iRow = 2:2:decY_ % y-o
-                for iCol = 2:2:decX_ % x-o
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 2:2:decZ_ % z-o
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Boee
-            for iRow = 2:2:decY_ % y-o
-                for iCol = 1:2:decX_ % x-e
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 1:2:decZ_ % z-e
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %
-            value = coefs;
+            decY = decFactor(Direction.VERTICAL);
+            decX = decFactor(Direction.HORIZONTAL);
+            decZ = decFactor(Direction.DEPTH);
+
+            % Generate DCT matrices
+            Cv_ = dctmtx(decY);
+            Ch_ = dctmtx(decX);
+            Cd_ = dctmtx(decZ);
+
+            % Reorder rows using a single matrix operation
+            reorder = @(C) C([1:2:end, 2:2:end], :);
+            Cv_ = reorder(Cv_);
+            Ch_ = reorder(Ch_);
+            Cd_ = reorder(Cd_);
+
+            % Split matrices into even and odd parts
+            split = @(C, n) deal(C(1:ceil(n/2), :), C(ceil(n/2)+1:end, :));
+            [Cve, Cvo] = split(Cv_, decY);
+            [Che, Cho] = split(Ch_, decX);
+            [Cde, Cdo] = split(Cd_, decZ);
+
+            % Compute Kronecker products
+            kron3 = @(A, B, C) kron(kron(A, B), C);
+            value = [
+                kron3(Cde, Che, Cve);
+                kron3(Cdo, Cho, Cve);
+                kron3(Cde, Cho, Cvo);
+                kron3(Cdo, Che, Cvo);
+                kron3(Cdo, Che, Cve);
+                kron3(Cde, Cho, Cve);
+                kron3(Cdo, Cho, Cvo);
+                kron3(Cde, Che, Cvo)
+            ];
         end
         
     end

--- a/code/+tansacnet/+testcase/+lsun/lsunBlockIdct3dLayerTestCase.m
+++ b/code/+tansacnet/+testcase/+lsun/lsunBlockIdct3dLayerTestCase.m
@@ -22,7 +22,7 @@ classdef lsunBlockIdct3dLayerTestCase < matlab.unittest.TestCase
     % http://msiplab.eng.niigata-u.ac.jp/
     %
     properties (TestParameter)
-        stride = { [1 1 1], [2 2 2], [1 2 4] };
+        stride = { [1 1 1], [2 2 2], [1 2 4], [4 4 4] };
         datatype = { 'single', 'double' };
         height = struct('small', 8,'medium', 16, 'large', 32);
         width = struct('small', 8,'medium', 16, 'large', 32);
@@ -265,143 +265,39 @@ classdef lsunBlockIdct3dLayerTestCase < matlab.unittest.TestCase
         
         function value = getMatrixE0_(decFactor)
             import tansacnet.utility.Direction
-            decY_ = decFactor(Direction.VERTICAL);
-            decX_ = decFactor(Direction.HORIZONTAL);
-            decZ_ = decFactor(Direction.DEPTH);
-            nElmBi = decY_*decX_*decZ_;
-            coefs = zeros(nElmBi);
-            iElm = 1;
-            % E0.'= [ Beee Beoo Booe Boeo Beeo Beoe Booo Boee ] % Byxz
-            % Beee
-            for iRow = 1:2:decY_ % y-e
-                for iCol = 1:2:decX_ % x-e
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 1:2:decZ_ % z-e
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            % Beoo
-            for iRow = 1:2:decY_ % y-e
-                for iCol = 2:2:decX_ % x-o
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 2:2:decZ_ % z-o
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Booe
-            for iRow = 2:2:decY_ % y-o
-                for iCol = 2:2:decX_ % x-o
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 1:2:decZ_ % z-e
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Boeo
-            for iRow = 2:2:decY_ % y-o
-                for iCol = 1:2:decX_ % x-e
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 2:2:decZ_ % z-o
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Beeo
-            for iRow = 1:2:decY_ % y-e
-                for iCol = 1:2:decX_ % x-e
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 2:2:decZ_ % z-o
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Beoe
-            for iRow = 1:2:decY_ % y-e
-                for iCol = 2:2:decX_ % x-o
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 1:2:decZ_ % z-e
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Booo
-            for iRow = 2:2:decY_ % y-o
-                for iCol = 2:2:decX_ % x-o
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 2:2:decZ_ % z-o
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %Boee
-            for iRow = 2:2:decY_ % y-o
-                for iCol = 1:2:decX_ % x-e
-                    dctCoefYX = zeros(decY_,decX_);
-                    dctCoefYX(iRow,iCol) = 1;
-                    basisYX = idct2(dctCoefYX);
-                    for iDep = 1:2:decZ_ % z-e
-                        dctCoefZ = zeros(decZ_,1);
-                        dctCoefZ(iDep) = 1;
-                        basisZ  = permute(idct(dctCoefZ),[2 3 1]);
-                        basisVd = convn(basisZ,basisYX);
-                        coefs(iElm,:) = basisVd(:).';
-                        iElm = iElm + 1;
-                    end
-                end
-            end
-            %
-            value = coefs;
+            decY = decFactor(Direction.VERTICAL);
+            decX = decFactor(Direction.HORIZONTAL);
+            decZ = decFactor(Direction.DEPTH);
+
+            % Generate DCT matrices
+            Cv_ = dctmtx(decY);
+            Ch_ = dctmtx(decX);
+            Cd_ = dctmtx(decZ);
+
+            % Reorder rows using a single matrix operation
+            reorder = @(C) C([1:2:end, 2:2:end], :);
+            Cv_ = reorder(Cv_);
+            Ch_ = reorder(Ch_);
+            Cd_ = reorder(Cd_);
+
+            % Split matrices into even and odd parts
+            split = @(C, n) deal(C(1:ceil(n/2), :), C(ceil(n/2)+1:end, :));
+            [Cve, Cvo] = split(Cv_, decY);
+            [Che, Cho] = split(Ch_, decX);
+            [Cde, Cdo] = split(Cd_, decZ);
+
+            % Compute Kronecker products
+            kron3 = @(A, B, C) kron(kron(A, B), C);
+            value = [
+                kron3(Cde, Che, Cve);
+                kron3(Cdo, Cho, Cve);
+                kron3(Cde, Cho, Cvo);
+                kron3(Cdo, Che, Cvo);
+                kron3(Cdo, Che, Cve);
+                kron3(Cde, Cho, Cve);
+                kron3(Cdo, Cho, Cvo);
+                kron3(Cde, Che, Cvo)
+            ];
         end
         
     end

--- a/code/+tansacnet/+testcase/+lsun/lsunSynthesis1dNetworkTestCase.m
+++ b/code/+tansacnet/+testcase/+lsun/lsunSynthesis1dNetworkTestCase.m
@@ -143,7 +143,7 @@ classdef lsunSynthesis1dNetworkTestCase < matlab.unittest.TestCase
                 'DType',datatype, ...
                 'Device',device);
             SYNdlnet = SYNnet.dlnetwork();
-            analyzeNetwork(SYNdlnet)
+            % analyzeNetwork(SYNdlnet)
             SYNdlnet_ = initialize(SYNdlnet);
             Z = forward(SYNdlnet_, Xac, Xdc);
 
@@ -203,7 +203,7 @@ classdef lsunSynthesis1dNetworkTestCase < matlab.unittest.TestCase
                 'DType',datatype, ...
                 'Device',device);
             dlnet = net.dlnetwork();
-            analyzeNetwork(dlnet)
+            % analyzeNetwork(dlnet)
             dlnet_ = initialize(dlnet);
 
             Xac = dlarray(Xac,'SSCB');
@@ -303,7 +303,7 @@ classdef lsunSynthesis1dNetworkTestCase < matlab.unittest.TestCase
                 'DType',datatype, ...
                 'Device',device);
             dlnet = net.dlnetwork();
-            analyzeNetwork(dlnet)
+            % analyzeNetwork(dlnet)
             dlnet_ = initialize(dlnet);
 
             Xac = dlarray(Xac,'SSCB');


### PR DESCRIPTION
The previous implementation of 3D-DCT did not support more than 4 strides, so this has been corrected. 

Also, net.dlnetwork() in Analysis and Synthesis test cases is supported only in grades later than R2024a. 